### PR TITLE
fix: Correctly sign executables for MacOS

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -57,11 +57,11 @@ jobs:
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
             --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
 
-          echo "Stapling..."
-          for binary in bun bunv bunx; do
-            codesign --verify --verbose "$binary"
-            xcrun stapler staple -v "$binary"
-          done
+          # echo "Stapling..."
+          # for binary in bun bunv bunx; do
+          #   codesign --verify --verbose "$binary"
+          #   xcrun stapler staple -v "$binary"
+          # done
 
       - uses: vimtor/action-zip@v1.2
         with:

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -48,7 +48,6 @@ jobs:
           for binary in bun bunv bunx; do
             codesign --force --options runtime --sign "${{ secrets.APPLE_CERT_NAME }}" "$binary"
           done
-          ls -lA
 
           echo "Notarizing..."
           ditto -c -k --keepParent . binaries.zip
@@ -56,12 +55,6 @@ jobs:
             --apple-id "${{ secrets.APPLE_ID }}" \
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
             --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
-
-          # echo "Stapling..."
-          # for binary in bun bunv bunx; do
-          #   codesign --verify --verbose "$binary"
-          #   xcrun stapler staple -v "$binary"
-          # done
 
       - uses: vimtor/action-zip@v1.2
         with:

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -50,12 +50,12 @@ jobs:
           done
           ls -lA
 
-          echo "Notarizing..."
-          ditto -c -k --keepParent . binaries.zip
-          xcrun notarytool submit binaries.zip --wait \
-            --apple-id "${{ secrets.APPLE_ID }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
+          # echo "Notarizing..."
+          # ditto -c -k --keepParent . binaries.zip
+          # xcrun notarytool submit binaries.zip --wait \
+          #   --apple-id "${{ secrets.APPLE_ID }}" \
+          #   --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+          #   --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
 
           # echo "Stapling..."
           # for binary in bun bunv bunx; do

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -50,12 +50,12 @@ jobs:
           done
           ls -lA
 
-          # echo "Notarizing..."
-          # ditto -c -k --keepParent . binaries.zip
-          # xcrun notarytool submit binaries.zip --wait \
-          #   --apple-id "${{ secrets.APPLE_ID }}" \
-          #   --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-          #   --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
+          echo "Notarizing..."
+          ditto -c -k --keepParent . binaries.zip
+          xcrun notarytool submit binaries.zip --wait \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
 
           # echo "Stapling..."
           # for binary in bun bunv bunx; do

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -48,6 +48,7 @@ jobs:
           for binary in bun bunv bunx; do
             codesign --force --options runtime --sign "${{ secrets.APPLE_CERT_NAME }}" "$binary"
           done
+          ls -lA
 
           echo "Notarizing..."
           ditto -c -k --keepParent . binaries.zip
@@ -58,7 +59,8 @@ jobs:
 
           echo "Stapling..."
           for binary in bun bunv bunx; do
-            xcrun stapler staple "$binary"
+            codesign --verify --verbose "$binary"
+            xcrun stapler staple -v "$binary"
           done
 
       - uses: vimtor/action-zip@v1.2


### PR DESCRIPTION
After testing, it seems like we need to sign and notarize, but not staple. Tried stapling, got a weird error:

```
Downloaded ticket has been stored at file:///var/folders/0g/.../T/....ticket.
Could not remove existing ticket from bun/Contents/CodeResources -- file:///Users/runner/work/bunv/bunv/zig-out/bin/ because an error occurred. Error Domain=NSCocoaErrorDomain Code=512 "“CodeResources” couldn’t be removed." UserInfo={NSUserStringVariant=(
    Remove
), NSFilePath=/Users/runner/work/bunv/bunv/zig-out/bin/bun/Contents/CodeResources, NSUnderlyingError=0x6000015388d0 {Error Domain=NSPOSIXErrorDomain Code=20 "Not a directory"}}
The staple and validate action failed! Error 73.
```

Seemed like stapling doesn't seem to work on binarys, only .pkg files. Gatekeeper doesn't seem to fire if the binaries are signed an notarized, so that's what I'm doing.