### PR TITLE
chore(deps): Update zig version from 0.13.0 to 0.14.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,4 +5,4 @@ runs:
   steps:
     - uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.13.0
+        version: 0.14.0

--- a/build.zig
+++ b/build.zig
@@ -7,9 +7,9 @@ const bunx = "bunx";
 const bunv = "bunv";
 
 pub fn build(b: *std.Build) !void {
-    const required_zig_version = try std.SemanticVersion.parse("0.13.0");
+    const required_zig_version = try std.SemanticVersion.parse("0.14.0");
     if (std.SemanticVersion.order(builtin.zig_version, required_zig_version) != .eq) {
-        std.debug.print("Bunv requires Zig 0.13.0, got {}", .{builtin.zig_version});
+        std.debug.print("Bunv requires Zig 0.14.0, got {}", .{builtin.zig_version});
         return error.InvalidZigVersion;
     }
 


### PR DESCRIPTION
This change might seem minor, but it’s necessary for packaging `bunv` with various package managers. Most package managers right now only maintain the latest version of Zig, so depending on Zig 0.13 as a build dependency isn’t feasible.