### PR TITLE
feat: Display message when no versions are installed

### DIFF
--- a/src/bunv.zig
+++ b/src/bunv.zig
@@ -33,6 +33,10 @@ pub fn main() !void {
 
 fn printInstalledVersions(allocator: mem.Allocator, config_dir: []const u8, versions: std.ArrayList([]const u8)) !void {
     std.debug.print("{s}Installed versions:{s}\n", .{ c.bold, c.reset });
+    if (versions.items.len == 0) {
+        std.debug.print("  {s}No versions installed{s}\n", .{ c.yellow, c.reset });
+        return;
+    }
     for (versions.items) |version| {
         const directory = try vm.getVersionDir(allocator, config_dir, version);
         defer allocator.free(directory);


### PR DESCRIPTION
## Summary
- Added a message indicating "No versions installed" when no versions are available
- Message is displayed in yellow to maintain consistent color scheme with warnings

![image](https://github.com/user-attachments/assets/35b851ee-db97-4659-9f74-63f154dfb6b1)

## Test plan
- Build and run with `DEBUG=bunv BUNV_INSTALL=.bunv2 zig build bunv` to verify the message appears

🤖 Generated with [Claude Code](https://claude.ai/code)