### PR TITLE
fix: Add support for Zig 0.13 back

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,9 +7,9 @@ const bunx = "bunx";
 const bunv = "bunv";
 
 pub fn build(b: *std.Build) !void {
-    const required_zig_version = try std.SemanticVersion.parse("0.14.0");
-    if (std.SemanticVersion.order(builtin.zig_version, required_zig_version) != .eq) {
-        std.debug.print("Bunv requires Zig 0.14.0, got {}", .{builtin.zig_version});
+    const min_zig_version = try std.SemanticVersion.parse("0.13.0");
+    if (std.SemanticVersion.order(builtin.zig_version, min_zig_version) == .lt) {
+        std.debug.print("Bunv requires Zig 0.13.0 or above, got {}", .{builtin.zig_version});
         return error.InvalidZigVersion;
     }
 


### PR DESCRIPTION
## Summary
- Modified the build.zig file to accept Zig 0.13.0 and above instead of requiring exactly 0.14.0
- This is needed because the Arch Linux package hasn't been updated to Zig 0.14 yet
- Users will now be able to build the project with either Zig 0.13.0 or newer versions

## Test plan
- [x] Verify the build works with Zig 0.13.0 (on arch)
- [x] Verify the build works with Zig 0.14.0 and above (on CI)

🤖 Generated with [Claude Code](https://claude.ai/code)