### PR TITLE
fix: gracefully handle UserAborted errors

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -6,5 +6,5 @@ pub fn main() !void {
     defer _ = gpa.deinit();
 
     const allocator = gpa.allocator();
-    try utils.run(allocator, utils.Cmd.bun);
+    utils.run_main(allocator, utils.Cmd.bun);
 }

--- a/src/bunx.zig
+++ b/src/bunx.zig
@@ -6,5 +6,5 @@ pub fn main() !void {
     defer _ = gpa.deinit();
 
     const allocator = gpa.allocator();
-    try utils.run(allocator, utils.Cmd.bunx);
+    utils.run_main(allocator, utils.Cmd.bunx);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -11,6 +11,16 @@ pub const Cmd = enum {
     bunx,
 };
 
+/// Wrapper for run that handles common errors like UserAborted
+pub fn run_main(allocator: mem.Allocator, cmd: Cmd) void {
+    run(allocator, cmd) catch |err| {
+        // Just exit gracefully for UserAborted since we already displayed an error message
+        if (err == error.UserAborted) std.process.exit(1);
+        std.debug.print("Error: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+}
+
 pub fn run(allocator: mem.Allocator, cmd: Cmd) !void {
     const is_debug = try isDebug(allocator);
     if (is_debug) std.debug.print("Executable: {}\n", .{cmd});


### PR DESCRIPTION
## Summary
- Add a wrapper function `run_main` to handle errors consistently across all binaries
- Specifically catch `UserAborted` errors and exit gracefully without a stack trace
- Provides a cleaner user experience when installation is skipped

## Test plan
- Run `bun` or `bunx` with no version installed in a non-interactive terminal
- Should now exit cleanly without a stack trace, just showing the error message

🤖 Generated with [Claude Code](https://claude.ai/code)