### PR TITLE
fix: create parent directories before installation

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -159,6 +159,9 @@ pub fn ensureVersionDownloaded(allocator: mem.Allocator, config_dir: []const u8,
 
     std.debug.print("Installing...\n", .{});
 
+    // Ensure the config directory exists before proceeding
+    try fs.makeDirAbsolute(config_dir);
+
     const install_script_path = try fs.path.join(allocator, &[_][]const u8{ config_dir, "install.sh" });
     defer allocator.free(install_script_path);
 


### PR DESCRIPTION
## Summary
- Added directory creation before attempting to install Bun 
- Fixes issue where the CLI fails when ~/.bunv doesn't exist
- Creates the parent directory structure before writing files

## Test plan
- Remove ~/.bunv directory and run the CLI
- Should now create the directory as needed

🤖 Generated with [Claude Code](https://claude.ai/code)