### PR TITLE
refactor: replace error propagation with direct exit codes

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -6,5 +6,5 @@ pub fn main() !void {
     defer _ = gpa.deinit();
 
     const allocator = gpa.allocator();
-    utils.run_main(allocator, utils.Cmd.bun);
+    try utils.run(allocator, utils.Cmd.bun);
 }

--- a/src/bunx.zig
+++ b/src/bunx.zig
@@ -6,5 +6,5 @@ pub fn main() !void {
     defer _ = gpa.deinit();
 
     const allocator = gpa.allocator();
-    utils.run_main(allocator, utils.Cmd.bunx);
+    try utils.run(allocator, utils.Cmd.bunx);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -11,15 +11,6 @@ pub const Cmd = enum {
     bunx,
 };
 
-/// Wrapper for run that handles common errors like UserAborted
-pub fn run_main(allocator: mem.Allocator, cmd: Cmd) void {
-    run(allocator, cmd) catch |err| {
-        // Just exit gracefully for UserAborted since we already displayed an error message
-        if (err == error.UserAborted) std.process.exit(1);
-        std.debug.print("Error: {s}\n", .{@errorName(err)});
-        std.process.exit(1);
-    };
-}
 
 pub fn run(allocator: mem.Allocator, cmd: Cmd) !void {
     const is_debug = try isDebug(allocator);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -11,7 +11,6 @@ pub const Cmd = enum {
     bunx,
 };
 
-
 pub fn run(allocator: mem.Allocator, cmd: Cmd) !void {
     const is_debug = try isDebug(allocator);
     if (is_debug) std.debug.print("Executable: {}\n", .{cmd});

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -246,7 +246,8 @@ fn confirmInstallation(version: []const u8) !void {
         try stdout.print("{s}Bun v{s} is not installed. Run in an interactive terminal to install or set BUNV_AUTO_INSTALL=1.{s}\n", .{ c.yellow, version, c.reset });
     }
 
-    return error.UserAborted;
+    std.debug.print("Installation aborted by user\n", .{});
+    std.process.exit(1);
 }
 
 pub fn getVersionsDir(allocator: mem.Allocator, config_dir: []const u8) ![]u8 {


### PR DESCRIPTION
## Summary
- Remove `run_main` function wrapper in favor of direct exit codes
- Add logging message when user aborts an installation
- Fix return type on `run` function to properly propagate errors

## Test plan
- Verify that all build targets compile successfully with `zig build`
- Test basic execution of the commands to ensure errors are properly displayed
- Verify explicit error handling with appropriate exit codes throughout the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)