### PR TITLE
fix: correct exit code check for bun installation process

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -217,7 +217,7 @@ pub fn ensureVersionDownloaded(allocator: mem.Allocator, config_dir: []const u8,
     defer allocator.free(installProcess.stderr);
     defer allocator.free(installProcess.stdout);
 
-    if (installProcess.term.Exited == 0) {
+    if (installProcess.term.Exited != 0) {
         std.debug.print("Failed to install Bun:\n\nSTDERR:\n{s}\n\nSTDOUT:\n{s}\n", .{ installProcess.stderr, installProcess.stdout });
         std.process.exit(1);
     }


### PR DESCRIPTION
Fixes issue #28 where bunv incorrectly reports "Failed to install Bun" despite successful installation.

## Problem

The installation process was checking exit codes incorrectly in `src/vm.zig` line 220:

```zig
if (installProcess.term.Exited == 0) {
    std.debug.print("Failed to install Bun:\n\nSTDERR:\n{s}\n\nSTDOUT:\n{s}\n", .{ installProcess.stderr, installProcess.stdout });
    std.process.exit(1);
}
```

In Unix/Linux systems:
- Exit code `0` means **SUCCESS** 
- Exit code `!= 0` means **FAILURE**

The condition was backwards, treating successful installations (exit code 0) as failures.

## Example of the Bug

```shell
❯ bun --version
Bun v1.2.18 is not installed. Do you want to install it? [y/N] y
Installing...
Failed to install Bun:

STDOUT:
-e bun was installed successfully to ~/.bunv/versions/1.2.18/bin/bun 
Run 'bun --help' to get started
```

## Solution

Changed the condition from `== 0` to `!= 0` to correctly detect failures:

```zig
if (installProcess.term.Exited != 0) {
    std.debug.print("Failed to install Bun:\n\nSTDERR:\n{s}\n\nSTDOUT:\n{s}\n", .{ installProcess.stderr, installProcess.stdout });
    std.process.exit(1);
}
```

Now:
- ✅ Successful installation (exit code 0) → Shows success message  
- ✅ Failed installation (exit code ≠ 0) → Shows error message and exits

## Changes

- **1 character change** in `src/vm.zig` line 220: `==` → `!=`
- Makes the code consistent with other exit code checks in the same file (line 186)

Closes #28